### PR TITLE
2507: Add section for nix-based build helpers

### DIFF
--- a/_posts/2025-07-08-FEX-2507.md
+++ b/_posts/2025-07-08-FEX-2507.md
@@ -44,4 +44,14 @@ again.
 This launcher has been a thorn in our side for years. It has some anti-debugger tech built in to it for some reason which always prevented all Ubisoft
 games from launching. We have now fixed this in FEX and it now works as well as expected. Now various Ubisoft games can be played! Have fun!
 
-See the [2507 Release Notes](https://github.com/FEX-Emu/FEX/releases/tag/FEX-2507) or the [detailed change log](https://github.com/FEX-Emu/FEX/compare/FEX-2507...FEX-2507) in Github.
+## A new cross-compilation setup
+
+Developers and testers living on the edge will know this long-standing issue: Parts of FEX require a full x86 cross-toolchain to build, but surprisingly few Linux distributions ship a setup that works out of the box. Setting things up manually is tricky enough that we couldn't even provide the most generic instructions to do so, so we've been searching for a way to make life easier for people. We've finally found a good solution: The [package manager Nix](https://en.wikipedia.org/wiki/Nix_(package_manager))!
+
+Once Nix is installed, it now only takes a call to one of FEX's bundled [helper scripts](https://github.com/FEX-Emu/FEX/tree/main/Data/nix) to build our x86-native FEXLinuxTests or to enable the library forwarding feature for improved emulation performance. For usage details, head over to the [pull request](https://github.com/FEX-Emu/FEX/pull/4632/) that added the helpers.
+
+A sweet little bonus: This same system allows you to automatically set up the toolchain required for building FEX as a WoW64/ARM64EC emulation module!
+
+---
+
+See the [2507 Release Notes](https://github.com/FEX-Emu/FEX/releases/tag/FEX-2507) or the [detailed change log](https://github.com/FEX-Emu/FEX/compare/FEX-2506...FEX-2507) in Github.


### PR DESCRIPTION
Seems worth mentioning these since it impacts FEX's build story.

Also added a separator at the bottom and fixed the detailed changes link.